### PR TITLE
Update the version support for yhmtsai#KeepZotero.json

### DIFF
--- a/addons/yhmtsai#KeepZotero.json
+++ b/addons/yhmtsai#KeepZotero.json
@@ -1,9 +1,13 @@
 {
   "repo": "yhmtsai/KeepZotero",
   "releases": [
+    {   
+      "targetZoteroVersion": "7",
+      "tagName": "latest"
+    },
     {
       "targetZoteroVersion": "6",
-      "tagName": "latest"
+      "tagName": "v0.0.2"
     }
   ]
 }


### PR DESCRIPTION
Hi, I recently update KeepZotero to support Zotero 7.
Zotero 6 can use v0.0.2, but Zotero 7 need to use the version from v0.1.0 (latest)
please let me know if I miss anything.