### PR TITLE
feat: add Ares960826/zotero-grouptag

### DIFF
--- a/addons/Ares960826#zotero-grouptag.json
+++ b/addons/Ares960826#zotero-grouptag.json
@@ -1,9 +1,0 @@
-{
-  "repo": "Ares960826/zotero-grouptag",
-  "releases": [
-    {
-      "targetZoteroVersion": "7,8,9",
-      "tagName": "latest"
-    }
-  ]
-}

--- a/addons/Ares960826#zotero-grouptag.json
+++ b/addons/Ares960826#zotero-grouptag.json
@@ -1,0 +1,10 @@
+{
+  repo: "Ares960826/zotero-grouptag",
+  releases: [
+    {
+      targetZoteroVersion: "7,8,9",
+      tagName: "latest",
+    }
+  ],
+  tags: ['interface'],
+}

--- a/addons/Ares960826#zotero-grouptag.json
+++ b/addons/Ares960826#zotero-grouptag.json
@@ -1,0 +1,9 @@
+{
+  "repo": "Ares960826/zotero-grouptag",
+  "releases": [
+    {
+      "targetZoteroVersion": "7,8,9",
+      "tagName": "latest"
+    }
+  ]
+}


### PR DESCRIPTION
Chrome-style visual tab grouping for the Zotero PDF reader —— Adds colored group headers and underline indicators to the Zotero tab bar, lets you create named groups, and manage tab assignments — all from a right-click context menu.

<img width="3840" height="442" alt="zotero_demo" src="https://github.com/user-attachments/assets/74d3c02c-c3f6-4c0d-aeca-5e1ef52bae4b" />
