### PR TITLE
Add zotero-random-read addon entry

### DIFF
--- a/addons/heimi98@zotero-random-read
+++ b/addons/heimi98@zotero-random-read
@@ -1,0 +1,1 @@
+{"tags": ["reader", "utility"]}

--- a/addons/heimi98@zotero-random-read
+++ b/addons/heimi98@zotero-random-read
@@ -1,1 +1,1 @@
-{"tags": ["reader", "utility"]}
+{"tags": ["utility"]}


### PR DESCRIPTION
Adds `heimi98/zotero-random-read` to the scraper addon list so the repository can be indexed and published into `addon_infos.json`.

The plugin already has a `v0.1.0` release with a GitHub-hosted XPI asset.