### PR TITLE
Add BabelDOC Side-by-Side plugin

### DIFF
--- a/addons/Babylonehy@zetero-BabelDoc
+++ b/addons/Babylonehy@zetero-BabelDoc
@@ -1,0 +1,1 @@
+{"tags": ["reader", "ai"]}

--- a/addons/Babylonehy@zetero-BabelDoc
+++ b/addons/Babylonehy@zetero-BabelDoc
@@ -1,1 +1,1 @@
-{"tags": ["reader", "ai"]}
+{"tags": ["ai"]}


### PR DESCRIPTION
## Add addon: Babylonehy/zetero-BabelDoc

A Zotero 8/9 plugin that calls local BabelDOC CLI to translate PDFs into bilingual side-by-side documents and imports results back into Zotero.

- **Tags**: `reader`, `ai`
- **Repo**: https://github.com/Babylonehy/zetero-BabelDoc
- **Latest release**: [v0.1.3](https://github.com/Babylonehy/zetero-BabelDoc/releases/tag/v0.1.3)