### PR TITLE
Add Zotero Figure Overview addon

### DIFF
--- a/addons/heimi98@zotero-figure-overview
+++ b/addons/heimi98@zotero-figure-overview
@@ -1,0 +1,1 @@
+{"tags": ["reader", "interface"]}


### PR DESCRIPTION
## Summary

Add `heimi98/zotero-figure-overview` to the scraper addon registry.

The plugin is a Zotero 9 add-on for browsing Zotero Reader image annotations in an Eagle-style overview window. It is tagged as:

- `reader`: it works with Zotero Reader image annotations and opens source annotations in the reader
- `interface`: it adds a top-bar entry point and an overview browsing UI

## Release

- Repository: https://github.com/heimi98/zotero-figure-overview
- Initial release: https://github.com/heimi98/zotero-figure-overview/releases/tag/v0.1.0
- XPI asset: https://github.com/heimi98/zotero-figure-overview/releases/download/v0.1.0/zotero-figure-overview.xpi

## Validation

- `PYTHONPATH=src python3 -m zotero_scraper.tag_review --files addons/heimi98@zotero-figure-overview`
