### PR TITLE
Add Zotero Settings Sync plugin

### DIFF
--- a/addons/gaviiiinnnn@zotero-settings-sync
+++ b/addons/gaviiiinnnn@zotero-settings-sync
@@ -1,0 +1,1 @@
+{"tags": ["utility"]}


### PR DESCRIPTION
Add `gaviiiinnnn/zotero-settings-sync` to the scraper add-on registry.

Zotero Settings Sync is a Zotero 7/8/9 add-on for syncing Zotero preferences, plugin configurations, installed plugin files, custom citation styles, and site-specific Quick Copy export settings across devices.

- Tags: `utility`
- Repository: https://github.com/gaviiiinnnn/zotero-settings-sync
- Latest release: https://github.com/gaviiiinnnn/zotero-settings-sync/releases/tag/v1.2.2
- XPI asset: https://github.com/gaviiiinnnn/zotero-settings-sync/releases/download/v1.2.2/zotero-settings-sync.xpi