### PR TITLE
Added a4965898@zotero-AI-OCR to the addons list

### DIFF
--- a/addons/4965898@zotero-AI-OCR
+++ b/addons/4965898@zotero-AI-OCR
@@ -1,0 +1,1 @@
+{"tags": ["attachment"]}

--- a/addons/a4965898@zotero-AI-OCR
+++ b/addons/a4965898@zotero-AI-OCR
@@ -1,0 +1,1 @@
+{"tags": ["attachment	"]}

--- a/addons/a4965898@zotero-AI-OCR
+++ b/addons/a4965898@zotero-AI-OCR
@@ -1,1 +1,0 @@
-{"tags": ["attachment	"]}


### PR DESCRIPTION
AI OCR 是一款 Zotero 7 插件，支持调用 PaddleOCR 和 MinerU 在线 AI 引擎对 PDF 文档进行 OCR 识别，并将识别结果以 Markdown 笔记的形式附加到 Zotero 条目中。