### PR TITLE
Add mjthoraval/Weavero

### DIFF
--- a/addons/mjthoraval@Weavero
+++ b/addons/mjthoraval@Weavero
@@ -1,0 +1,1 @@
+{"tags": ["reader", "interface"]}


### PR DESCRIPTION
Adds [Weavero](https://github.com/mjthoraval/Weavero) — a Zotero plugin to make clickable links and filter your library: it turns URLs in annotation comments and notes into clickable links, and adds a fast filter pane, related-item plumbing, and items-tree columns on top of the standard library view.

Latest release: https://github.com/mjthoraval/Weavero/releases/latest (XPI + `update.json` published).

Tags: `reader`, `interface`.