### PR TITLE
Add zotero-doi-fix addon

### DIFF
--- a/addons/pandaAIGC@zotero-doi-fix
+++ b/addons/pandaAIGC@zotero-doi-fix
@@ -1,0 +1,1 @@
+{"tags": ["metadata", "utility"]}


### PR DESCRIPTION
Adds pandaAIGC/zotero-doi-fix to the scraper source.\n\nRelease: https://github.com/pandaAIGC/zotero-doi-fix/releases/tag/v1.1.0\nTags: metadata, utility