### PR TITLE
Add MinerU HTML Parser for Zotero

### DIFF
--- a/addons/understandlxy@mineru-html-parser-zotero
+++ b/addons/understandlxy@mineru-html-parser-zotero
@@ -1,0 +1,1 @@
+{"tags": ["attachment", "utility"]}


### PR DESCRIPTION
Add understandlxy/mineru-html-parser-zotero to the Add-on Market scraper index. The plugin parses Zotero PDF attachments with the MinerU precise parsing API and attaches generated HTML output.