### PR TITLE
Add zotero-filelink-bridge addon

### DIFF
--- a/addons/ImagonTuTu@zotero-filelink-bridge
+++ b/addons/ImagonTuTu@zotero-filelink-bridge
@@ -1,0 +1,1 @@
+{"tags": ["attachment", "integration", "utility"]}

--- a/addons/ImagonTuTu@zotero-filelink-bridge
+++ b/addons/ImagonTuTu@zotero-filelink-bridge
@@ -1,1 +1,1 @@
-{"tags": ["attachment", "integration", "utility"]}
+{"tags": ["attachment", "utility"]}


### PR DESCRIPTION
  Add Zotero FileLink Bridge to the addon scraper index.

  Tags: attachment, integration, utility.