### PR TITLE
Update Suppr Zotero plugin tags

### DIFF
--- a/addons/WildDataX@suppr-zotero-plugin
+++ b/addons/WildDataX@suppr-zotero-plugin
@@ -1,1 +1,1 @@
-{"tags": ["reader"]}
+{"tags": ["ai", "reader"]}


### PR DESCRIPTION
This updates the existing Suppr Zotero Plugin entry from eader to i + eader. The add-on provides AI-assisted document translation workflows in Zotero, so the additional i tag should make it easier to discover in Zotero Addons.\n\nRepository: https://github.com/WildDataX/suppr-zotero-plugin\nLatest release includes suppr.xpi: https://github.com/WildDataX/suppr-zotero-plugin/releases/latest