### PR TITLE
Add Zotero Annotation Markdown

### DIFF
--- a/addons/qrkks@zotero-annotation-markdown
+++ b/addons/qrkks@zotero-annotation-markdown
@@ -1,0 +1,1 @@
+{"tags":["reader","notes"]}


### PR DESCRIPTION
Adds `qrkks/zotero-annotation-markdown` to the scraper source.

Plugin: https://github.com/qrkks/zotero-annotation-markdown
Latest release: https://github.com/qrkks/zotero-annotation-markdown/releases/latest

Tags: reader, notes

Validation:
- `python -m json.tool addons/qrkks@zotero-annotation-markdown`
- `git diff --check`
- `python -m pytest` — 72 passed, 2 warnings