### PR TITLE
Add rikochyou/zotero-smart-clipboard-import

### DIFF
--- a/addons/rikochyou@zotero-smart-clipboard-import
+++ b/addons/rikochyou@zotero-smart-clipboard-import
@@ -1,0 +1,1 @@
+{"tags": ["ai", "metadata"]}

--- a/addons/rikochyou@zotero-smart-clipboard-import
+++ b/addons/rikochyou@zotero-smart-clipboard-import
@@ -1,1 +1,1 @@
-{"tags": ["ai", "metadata"]}
+{"tags": ["metadata"]}


### PR DESCRIPTION
Add [zotero-smart-clipboard-import](https://github.com/rikochyou/zotero-smart-clipboard-import) plugin entry.

A Zotero 7 plugin that intelligently imports references from clipboard with multi-source metadata resolution (doi.org, Crossref, Semantic Scholar, OpenAlex) and optional LLM fallback parsing.

Tags: `ai`, `metadata`