### PR TITLE
Add xuhan-rgb/zotero-ai-sidebar

### DIFF
--- a/addons/xuhan-rgb@zotero-ai-sidebar
+++ b/addons/xuhan-rgb@zotero-ai-sidebar
@@ -1,0 +1,1 @@
+{"tags": ["ai", "interface"]}

--- a/addons/xuhan-rgb@zotero-ai-sidebar
+++ b/addons/xuhan-rgb@zotero-ai-sidebar
@@ -1,1 +1,1 @@
-{"tags": ["ai", "interface"]}
+{"tags": ["ai"]}


### PR DESCRIPTION
Adds `addons/xuhan-rgb@zotero-ai-sidebar` to include **Zotero AI Sidebar** in the scraper.

- Repo: https://github.com/xuhan-rgb/zotero-ai-sidebar
- A separate AI chat column inside Zotero that reads the current item, PDF text, annotations, selected text, and screenshots through a local tool harness (Claude / OpenAI).
- Features: click-to-translate, direct LaTeX parsing of formula images, paper summarization, and a three-column PDF | note | chat layout.
- Public repo with GitHub Releases; latest `v0.5.4` ships `zotero-ai-sidebar.xpi`. Supports Zotero 7/8/9 (`strict_min_version` 7.0).

Tags: `ai`, `interface`.
