### PR TITLE
Add listen2papers-zotero

### DIFF
--- a/addons/ysqander@listen2papers-zotero
+++ b/addons/ysqander@listen2papers-zotero
@@ -1,0 +1,1 @@
+{"tags": ["reader", "integration"]}


### PR DESCRIPTION
## Summary

Adds `ysqander/listen2papers-zotero` to the add-on registry.

The plugin is an open-source Zotero Desktop add-on for turning a selected local PDF attachment into generated paper audio with synchronized read-along text and saved progress.

## Tags

- `reader` for the PDF/read-along experience
- `integration` for the listen2papers service connection

## Validation

```bash
PYTHONPATH=src python3 -m zotero_scraper.tag_review --files addons/ysqander@listen2papers-zotero
```
