### PR TITLE
Add arxiv-marker

### DIFF
--- a/addons/lelelelelelelelelelelelele@arxiv-marker
+++ b/addons/lelelelelelelelelelelelele@arxiv-marker
@@ -1,0 +1,1 @@
+{"tags": ["metadata"]}


### PR DESCRIPTION
Adds **arxiv-marker** — a native Zotero 7/9 plugin that resolves the real publication venue (NeurIPS / ICLR / CVPR…) of the arXiv preprints in your library and writes it back as proper metadata, so easyScholar / zotero-style / Citation Tally light up for them. Deterministic (Semantic Scholar + DBLP), review-before-write, never creates duplicates.

Repo: https://github.com/lelelelelelelelelelelelele/arxiv-marker
Latest release: **v0.2.0** (ships `arxiv-marker-0.2.0.xpi` + `update.json` for auto-update)
Tag: `metadata` (same as Citation Tally — venue / citation-count metadata)