### PR TITLE
Add CloseFlow addon

### DIFF
--- a/addons/LoveTheStar7@Zotero-CloseFlow
+++ b/addons/LoveTheStar7@Zotero-CloseFlow
@@ -1,0 +1,1 @@
+{"tags": ["interface", "utility"]}

--- a/addons/LoveTheStar7@Zotero-CloseFlow
+++ b/addons/LoveTheStar7@Zotero-CloseFlow
@@ -1,1 +1,1 @@
-{"tags": ["interface", "utility"]}
+{"tags": ["utility"]}


### PR DESCRIPTION
Add CloseFlow to the Zotero add-ons scraper index.

Repository: https://github.com/LoveTheStar7/Zotero-CloseFlow
Latest release: https://github.com/LoveTheStar7/Zotero-CloseFlow/releases/tag/v1.2.5
Tags: interface, utility