### PR TITLE
Add Zotero GitHub Links addon

### DIFF
--- a/addons/Huoyuuu@zotero-github-links
+++ b/addons/Huoyuuu@zotero-github-links
@@ -1,0 +1,1 @@
+{"tags": ["integration", "interface"]}


### PR DESCRIPTION
Adds Huoyuuu/zotero-github-links to the addons list.\n\n- Add-on: Zotero GitHub Links\n- Repository: https://github.com/Huoyuuu/zotero-github-links\n- Latest release: https://github.com/Huoyuuu/zotero-github-links/releases/tag/v1.0.3\n- Tags: integration, interface\n\nValidation: ran python -m pytest locally: 72 passed.