### PR TITLE
Add Zotero AI LaTeX addon

### DIFF
--- a/addons/Huoyuuu@zotero-ai-latex
+++ b/addons/Huoyuuu@zotero-ai-latex
@@ -1,1 +1,1 @@
-{"tags": ["ai", "utility"]}
+{"tags": ["ai"]}

--- a/addons/Huoyuuu@zotero-ai-latex
+++ b/addons/Huoyuuu@zotero-ai-latex
@@ -1,0 +1,1 @@
+{"tags": ["ai", "utility"]}


### PR DESCRIPTION
Adds Huoyuuu/zotero-ai-latex to the addons list.\n\nRelease: https://github.com/Huoyuuu/zotero-ai-latex/releases/tag/v1.0.0