### PR TITLE
Add ZotRead (cannolis/ZotRead)

### DIFF
--- a/addons/cannolis@ZotRead
+++ b/addons/cannolis@ZotRead
@@ -1,0 +1,1 @@
+{"tags": ["ai", "interface"]}


### PR DESCRIPTION
Adds **ZotRead** to the add-on scraper.

- **Repo**: https://github.com/cannolis/ZotRead
- **Latest release**: https://github.com/cannolis/ZotRead/releases/latest (v0.1.9)
- **License**: AGPL-3.0
- **Zotero**: 7+

ZotRead scores papers in your Zotero library by relevance to your own published work or to a research-idea text, using any OpenAI-compatible LLM (DeepSeek by default; OpenAI / OpenRouter / local Ollama also supported). It adds a sortable Relevance column, a WhyRead sidebar pane explaining each rank, and an auto-maintained "ZotRead Top" collection.

Entry: `addons/cannolis@ZotRead` with `{"tags": ["ai", "interface"]}`.