### PR TITLE
Add astro-koko/deepseek-copilot-for-zotero

### DIFF
--- a/addons/astro-koko@deepseek-copilot-for-zotero
+++ b/addons/astro-koko@deepseek-copilot-for-zotero
@@ -1,0 +1,1 @@
+{"tags": ["ai", "reader"]}


### PR DESCRIPTION
Adds DeepSeek Copilot for Zotero to the scraper source.

- Repo: https://github.com/astro-koko/deepseek-copilot-for-zotero
- Latest stable release: v0.9.3
- Install asset: DS.Copilot-0.9.3.xpi
- Tags: ai, reader

Why these tags:
- `ai`: DeepSeek-powered paper Q&A and explanation inside Zotero
- `reader`: native PDF Reader selection flows (`Explain` / `Ask...`) and sidebar reading workflow
