### PR TITLE
Add Zotero PDF Copier & Renamer

### DIFF
--- a/addons/iu-parvej@Zotero-PDF-Copier-Renamer
+++ b/addons/iu-parvej@Zotero-PDF-Copier-Renamer
@@ -1,0 +1,1 @@
+{"tags": ["attachment", "utility"]}


### PR DESCRIPTION
Zotero PDF Copier & Renamer is a lightweight, fast extension for Zotero 7–9 that lets researchers easily extract, copy, and auto‑rename attached PDFs. It removes manual steps, organizes files with clean titles, prevents duplicates, and streamlines external workflows for academic and research use.