### PR TITLE
Add LuckYang1/PDF-to-md

### DIFF
--- a/addons/LuckYang1@PDF-to-md
+++ b/addons/LuckYang1@PDF-to-md
@@ -1,0 +1,1 @@
+{"tags": ["notes", "attachment"]}

--- a/addons/LuckYang1@PDF-to-md
+++ b/addons/LuckYang1@PDF-to-md
@@ -1,1 +1,1 @@
-{"tags": ["notes", "attachment"]}
+{"tags": ["utility", "attachment"]}


### PR DESCRIPTION
## Summary

Add `LuckYang1/PDF-to-md` to the add-on source list.

## Tags

- `notes`
- `attachment`

## Validation

- `python -m zotero_scraper.tag_review --files addons\LuckYang1@PDF-to-md`
- `python -m pytest -o addopts='' tests\unit\test_tag_review.py`
- Single-addon scraper run succeeded and parsed `v0.1.0` XPI from GitHub Releases.