### PR TITLE
Add metadata for zotero-docling plugin

### DIFF
--- a/addons/max3925vats@zotero-docling
+++ b/addons/max3925vats@zotero-docling
@@ -1,0 +1,1 @@
+{"tags": ["notes", "attachment"]}


### PR DESCRIPTION
Adds zotero-docling — converts PDF attachments to structured Markdown via the Docling document converter. Release v0.3.2 ships zotero-docling.xpi.