### PR TITLE
Add JournalLens addon metadata

### DIFF
--- a/addons/Lyz-623@JournalLens
+++ b/addons/Lyz-623@JournalLens
@@ -1,0 +1,1 @@
+{"tags": ["reader", "utility"]}

--- a/addons/Lyz-623@JournalLens
+++ b/addons/Lyz-623@JournalLens
@@ -1,1 +1,1 @@
-{"tags": ["reader", "utility"]}
+{"tags": ["metadata", "interface"]}


### PR DESCRIPTION
## Summary

Adds `Lyz-623@JournalLens` to the `addons/` directory so Zotero Addons scraper tooling can discover and categorize the JournalLens plugin.

## Addon

- Repository: https://github.com/Lyz-623/JournalLens
- Latest release: https://github.com/Lyz-623/JournalLens/releases/latest
- Update manifest: https://raw.githubusercontent.com/Lyz-623/JournalLens/main/updates.json
- Metadata added: `{"tags": ["reader", "utility"]}`

## Why These Tags

- `reader`: JournalLens helps users scan recent journal papers, read abstracts, translate paper information and inspect article figures inside Zotero.
- `utility`: it adds a practical Zotero workflow for following journals, searching title/abstract content and importing papers by DOI.

## Notes

JournalLens is a free and open-source Zotero plugin for following journals inside Zotero, browsing recent papers, viewing validated body / Extended Figure images, switching EN/中文 and saving papers to Zotero in one click.

This PR only adds the addon metadata entry; version and XPI details are provided by the JournalLens GitHub releases and update manifest.