### PR TITLE
Add Lyz-623@ZotAssets

### DIFF
--- a/addons/Lyz-623@ZotAssets
+++ b/addons/Lyz-623@ZotAssets
@@ -1,0 +1,1 @@
+{"tags": ["attachment", "utility"]}


### PR DESCRIPTION
Add **ZotAssets** to the add-on list.

- Repo: https://github.com/Lyz-623/ZotAssets
- Entry: `addons/Lyz-623@ZotAssets` → `{"tags": ["attachment", "utility"]}`
- Latest release: https://github.com/Lyz-623/ZotAssets/releases/latest (`ZotAssets-0.2.0.xpi` + `update.json`)
- Compatible with Zotero 7 / 8 / 9 (bootstrapped plugin).

**EN** — ZotAssets assigns an asset role (Main PDF, Supplement, Data, Code, Figure, Translation, Scan, Publisher version, Accepted manuscript, Preprint, Other) to each attachment, can auto-classify a whole library, and auto-renames PDFs from a template.

**中文** — ZotAssets 为每个附件标注资产角色，支持自动识别整个文献库，并按模板自动重命名 PDF。

Tags chosen: `attachment` (attachment/file organization) and `utility` (automation).
