### PR TITLE
Add DrinkTea905/zotero-paper-outline

### DIFF
--- a/addons/DrinkTea905@zotero-paper-outline
+++ b/addons/DrinkTea905@zotero-paper-outline
@@ -1,0 +1,1 @@
+{"tags": ["ai", "reader"]}


### PR DESCRIPTION
Add a new add-on entry: **DrinkTea905/zotero-paper-outline**

**Paper Outline** — uses AI to generate a hierarchical, page-numbered outline with per-section summaries for a paper, shown in the reader's left sidebar; click an entry to jump to the page. Bookmark-first, falls back to AI when the PDF has no embedded outline. Supports DeepSeek / OpenAI / Kimi / Zhipu / Qwen / SiliconFlow / Ollama.

- Repo: https://github.com/DrinkTea905/zotero-paper-outline
- Latest release with `.xpi`: https://github.com/DrinkTea905/zotero-paper-outline/releases/tag/v1.1.0
- Compatible with Zotero 7 / 8 / 9
- Tags: `ai`, `reader`