### PR TITLE
Add Zotero Assistant

### DIFF
--- a/addons/origin652@zotero-assistant
+++ b/addons/origin652@zotero-assistant
@@ -1,0 +1,1 @@
+{"tags": ["ai", "reader"]}


### PR DESCRIPTION
Adds [origin652/zotero-assistant](https://github.com/origin652/zotero-assistant) to the addon scraper list.

Zotero Assistant is an in-client AI assistant for Zotero 9. It provides a chat-based task interface for organizing references, reading current PDF/EPUB reader pages, creating notes, updating metadata, managing tags and collections, and running reversible library actions with approval controls and an audit log.

Tags: ai, reader

Release: https://github.com/origin652/zotero-assistant/releases/tag/v0.1.0