### PR TITLE
Add Fr_AI Zotero addon

### DIFF
--- a/addons/TangQi001@zotero-ai-assist
+++ b/addons/TangQi001@zotero-ai-assist
@@ -1,0 +1,1 @@
+{"tags":["ai","reader"]}


### PR DESCRIPTION
Add Fr_AI (TangQi001/zotero-ai-assist) to the Zotero addons scraper list.\n\nTags: i, eader.