### PR TITLE
Add josesiqueira/zotero-watch-folder

### DIFF
--- a/addons/josesiqueira@zotero-watch-folder
+++ b/addons/josesiqueira@zotero-watch-folder
@@ -1,0 +1,1 @@
+{"tags": ["attachment", "metadata"]}


### PR DESCRIPTION
Adds **Zotero Watch Folder** — watch a folder and auto-import PDFs with metadata retrieval, content-hash dedup, smart rules, template renaming, and optional two-way collection sync with recoverable safe-delete. Zotero 7/8/9 (live-verified on 9.0.4), GPL-3.0.

Entry: `addons/josesiqueira@zotero-watch-folder` with tags `attachment`, `metadata`.

Repo: https://github.com/josesiqueira/zotero-watch-folder