### PR TITLE
Add Causal Map for Zotero

### DIFF
--- a/addons/stevepowell99@causalmap-zotero
+++ b/addons/stevepowell99@causalmap-zotero
@@ -1,0 +1,1 @@
+{"tags": ["integration", "ai"]}


### PR DESCRIPTION
Adds [Causal Map for Zotero](https://github.com/stevepowell99/causalmap-zotero), which turns a Zotero item into a Causal Map project in the Causal Map web app.

Tags: `integration`, `ai`.