### PR TITLE
Add cislunarspace/bibtex-clean

### DIFF
--- a/addons/cislunarspace@bibtex-clean
+++ b/addons/cislunarspace@bibtex-clean
@@ -1,0 +1,1 @@
+{"tags": ["metadata"]}


### PR DESCRIPTION
## Plugin

- Repo: https://github.com/cislunarspace/bibtex-clean
- Latest release: v1.2.1
- Tag: `metadata`

## Description

BibTeX Clean 是一个 Zotero 插件，选中条目后通过右键菜单直接清理条目字段，让 BibTeX 导出更规范：

- 将 `author` 字段中的 `;` 替换为 `and`（兼容多作者分隔符）。
- 从 `number` 字段中移除汉字「第」「期」。
- 批量清理前通过确认对话框预览所有变更。
- 支持撤销最近一次清理操作。