### PR TITLE
Add zotero-duplicate-doctor addon

### DIFF
--- a/addons/pandaAIGC@zotero-duplicate-doctor
+++ b/addons/pandaAIGC@zotero-duplicate-doctor
@@ -1,0 +1,1 @@
+{"tags": ["utility"]}


### PR DESCRIPTION
Adds pandaAIGC/zotero-duplicate-doctor to the add-on scraper list.\n\nRepository: https://github.com/pandaAIGC/zotero-duplicate-doctor\nRelease: https://github.com/pandaAIGC/zotero-duplicate-doctor/releases/tag/v0.2.0\n\nThe add-on provides conservative duplicate auditing and safe same-DOI webpage-to-journalArticle merge support for Zotero.