### PR TITLE
Add psiQAQ/zotero-agent (Zotero MCP Plugin)

### DIFF
--- a/addons/psiQAQ@zotero-agent
+++ b/addons/psiQAQ@zotero-agent
@@ -1,0 +1,1 @@
+{"tags": ["ai", "utility"]}


### PR DESCRIPTION
Add [Zotero MCP Plugin](https://github.com/psiQAQ/zotero-agent) — an MCP server embedded in Zotero, providing 42 tools for AI clients (Claude, Codex, etc.) to interact with Zotero.

Tags: `ai` (AI-powered MCP protocol), `utility` (automation, deduplication, plugin management)