### PR TITLE
Add SHANGKAIJIE/zotero-hover-translate-eudic

### DIFF
--- a/addons/SHANGKAIJIE@zotero-hover-translate-eudic
+++ b/addons/SHANGKAIJIE@zotero-hover-translate-eudic
@@ -1,0 +1,1 @@
+{"tags": ["reader", "integration"]}


### PR DESCRIPTION
提交悬停翻译助手（Hover Translate Eudic）插件到插件列表。

- 仓库：SHANGKAIJIE/zotero-hover-translate-eudic
- 功能：在 Zotero PDF 阅读器内悬停/单击单词即时翻译（复用 Translate for Zotero 引擎），并支持一键同步到欧路词典云端生词本（欧路 OpenAPI）。
- 兼容：Zotero 7 / 8 / 9
- 已发布 Release（tag `release`）+ update.json，支持自动更新。
- 标签：reader（PDF 阅读内翻译/高亮）、integration（同步欧路 Eudic 外部服务）。
