### PR TITLE
Re-validate addon entry SHANGKAIJIE@zotero-hover-translate-eudic

### DIFF
--- a/addons/SHANGKAIJIE@zotero-hover-translate-eudic
+++ b/addons/SHANGKAIJIE@zotero-hover-translate-eudic
@@ -1,1 +1,1 @@
-{"tags": ["reader", "integration"]}
+{"tags":["reader","integration"]}


### PR DESCRIPTION
## Purpose
Re-trigger scraping for `SHANGKAIJIE/zotero-hover-translate-eudic` so it gets re-included in the marketplace data.

## Background
This plugin's repo was briefly renamed to `zotero-hover-translate-wordbook`, which caused a 404 during scraping and the entry was dropped from the published data. The repo name has since been restored to `zotero-hover-translate-eudic`:
- the addons entry file `addons/SHANGKAIJIE@zotero-hover-translate-eudic` is correct,
- the Release xpi (`zotero-hover-translate-eudic.xpi`) downloads fine (HTTP 200),
- the manifest display name is `Hover Translate Eudic`.

However, after the most recent successful scrape run, the published `addon_infos.json` still does not contain this plugin. The `release_cache` likely still holds a stale "removed/failed" marker from the 404 period, so a normal scheduled run keeps excluding it.

## Change
This PR makes a trivial formatting change to the entry file (`{"tags": ["reader", "integration"]}` -> `{"tags":["reader","integration"]}`). Tags are unchanged (reader + integration). The intent is to:
1. put the file into the `changed_addons` diff so the `tag_review` validation runs on it, and
2. trigger a push-driven full rescrape (`python main.py -i addons`) that re-fetches the repo and clears the stale cache marker.

## Links
- Repo: https://github.com/SHANGKAIJIE/zotero-hover-translate-eudic
- Release (xpi): https://github.com/SHANGKAIJIE/zotero-hover-translate-eudic/releases/tag/release

Thanks for merging / re-running the scrape!