### PR TITLE
Add wu-uk/zotero-feishu

### DIFF
--- a/addons/wu-uk@zotero-feishu
+++ b/addons/wu-uk@zotero-feishu
@@ -1,0 +1,1 @@
+{"tags": ["integration", "notes"]}


### PR DESCRIPTION
Adds Zotero Feishu Sync, a Zotero 8/9 plugin that synchronizes literature metadata, notes, images, and PDF attachments to Feishu Docs.

Repository: https://github.com/wu-uk/zotero-feishu
Release: https://github.com/wu-uk/zotero-feishu/releases/tag/v0.6.0