### PR TITLE
Add heimi98/zotero-deduplicator

### DIFF
--- a/addons/heimi98@zotero-deduplicator
+++ b/addons/heimi98@zotero-deduplicator
@@ -1,0 +1,1 @@
+{"tags": ["attachment", "utility"]}


### PR DESCRIPTION
## Summary

- Add `heimi98/zotero-deduplicator` to the addon registry
- Classify it with the `attachment` and `utility` tags

PDF Deduplicator detects duplicate Zotero PDF attachments by SHA-256 and lets users review them before moving duplicate items to the trash.

Plugin repository: https://github.com/heimi98/zotero-deduplicator

## Validation

- `PYTHONPATH=src python3 -m zotero_scraper.tag_review --files addons/heimi98@zotero-deduplicator`
- `PYTHONPATH=src .venv/bin/python -m pytest` (`74 passed`)
