### PR TITLE
Add wcmendes/MdBundle-for-Zotero

### DIFF
--- a/addons/wcmendes@MdBundle-for-Zotero
+++ b/addons/wcmendes@MdBundle-for-Zotero
@@ -1,0 +1,1 @@
+{"tags": ["attachment", "notes"]}


### PR DESCRIPTION
Add MdBundle for Zotero — a plugin to bundle, analyze & export PDF/MD attachments.

Features:
- Export matched PDF/MD pairs from selected items
- Diagnostic analysis of attachment health
- Generate MDs from PDFs (with OCR tagging)
- Select cited items from Word .docx documents
- 12 languages supported

Repo: https://github.com/wcmendes/MdBundle-for-Zotero
