### PR TITLE
Add Zotero TagNavigator

### DIFF
--- a/addons/arqueon@zotero-tagnavigator
+++ b/addons/arqueon@zotero-tagnavigator
@@ -1,0 +1,1 @@
+{"tags": ["interface", "utility"]}


### PR DESCRIPTION
## Add-on

Adds [Zotero TagNavigator](https://github.com/arqueon/zotero-tagnavigator), a Zotero-native interface for whole-library search, tag exploration, safe tag management, Quick Copy, and Zettlr citation formats.

- Latest release: [v1.3.0](https://github.com/arqueon/zotero-tagnavigator/releases/tag/v1.3.0)
- Add-on ID: `tagnavigator@arqueon.org`
- Zotero compatibility: 7–9
- Categories: `interface`, `utility`

## Validation

- The repository contains a public stable release with an `application/x-xpinstall` XPI asset.
- The scraper's XPI parser reads version 1.3.0, minimum version 6.999, maximum version 9.*, and the expected update URL.
- `python3 -m zotero_scraper.tag_review --files addons/arqueon@zotero-tagnavigator` passes.
