### PR TITLE
Add sbilmis/zotero-project-manager

### DIFF
--- a/addons/sbilmis@zotero-project-manager
+++ b/addons/sbilmis@zotero-project-manager
@@ -1,0 +1,1 @@
+{"tags": ["attachment", "notes"]}


### PR DESCRIPTION
## Add-on

- Repository: https://github.com/sbilmis/zotero-project-manager
- Latest release: https://github.com/sbilmis/zotero-project-manager/releases/tag/v1.0.0
- XPI asset: `zpm-zotero-1.0.0.xpi`

Zotero Project Manager exports selected collections into incremental research workspaces. The Zotero 7 plugin is self-contained and can export PDFs, annotations, notes, images, and optional non-PDF attachments.

Suggested tags: `attachment`, `notes`.
