### PR TITLE
Add Helloxiaolaodi/Zotero-StaticSync

### DIFF
--- a/addons/Helloxiaolaodi@Zotero-StaticSync
+++ b/addons/Helloxiaolaodi@Zotero-StaticSync
@@ -1,0 +1,1 @@
+{"tags": ["integration", "utility"]}


### PR DESCRIPTION
Add Zotero-StaticSync to the scraper list.

Zotero-StaticSync is a powerful plugin that seamlessly synchronizes Zotero collections and reading statuses (Unread, Claimed, Reported) with a Supabase database. It enables real-time, bi-directional collaboration and powers static web deployments for research teams, featuring automated tag-based state transitions and action syncing (like claiming/undoing) between the web frontend and the Zotero client.

**Add-on details:**
* **Repository:** https://github.com/Helloxiaolaodi/Zotero-StaticSync
* **Latest release:** https://github.com/Helloxiaolaodi/Zotero-StaticSync/releases/tag/v0.0.3
* **XPI asset:** zotero-static-sync-v0.0.3.xpi

Suggested tags: `integration`, `utility`