### PR TITLE
Add peterdresslar/zotero-gemini-notebook

### DIFF
--- a/addons/peterdresslar@zotero-gemini-notebook
+++ b/addons/peterdresslar@zotero-gemini-notebook
@@ -1,0 +1,1 @@
+{"tags": ["ai", "integration"]}

--- a/addons/peterdresslar@zotero-gemini-notebook
+++ b/addons/peterdresslar@zotero-gemini-notebook
@@ -1,1 +1,1 @@
-{"tags": ["attachment", "integration"]}
+{"tags": ["ai", "integration"]}

--- a/addons/peterdresslar@zotero-gemini-notebook
+++ b/addons/peterdresslar@zotero-gemini-notebook
@@ -1,1 +1,1 @@
-{"tags": ["ai", "integration"]}
+{"tags": ["attachment", "integration"]}


### PR DESCRIPTION
## Add-on

- Repository: https://github.com/peterdresslar/zotero-gemini-notebook
- Latest release: https://github.com/peterdresslar/zotero-gemini-notebook/releases/tag/v0.3.1
- Current name: **Zotero Gemini Notebook**
- Former name/search alias: **Zotero -> NotebookLM**
- Zotero plugin asset: `zotero-gemini-notebook.xpi`
- Required Chrome extension asset: `zotero-gemini-notebook-chrome-extension.zip`

Zotero Gemini Notebook, formerly Zotero -> NotebookLM, is a two-part integration
for Google's Gemini Notebook service (formerly NotebookLM). The Zotero plugin
lets users select and stage local Zotero attachments. The required Chrome
extension retrieves those explicitly staged files from Zotero's local server
and imports them into Gemini Notebook through its browser interface.

Both components are distributed together in the GitHub release. The current
release supports Zotero 7 through 9, was verified on Zotero 9.0.4 for macOS,
and includes Zotero plugin auto-updating. The unpacked Chrome extension must be
installed and updated separately in Chrome.

Suggested tags: `ai`, `integration`.

The `ai` tag reflects the add-on's user-facing destination and workflow:
Gemini Notebook/NotebookLM is Google's AI research and learning service. The
`integration` tag reflects the coordinated Zotero plugin and Chrome extension
that connect Zotero attachments to that external service.
