### PR TITLE
Add estravon-plugin

### DIFF
--- a/addons/tiberavonltd@estravon-plugin
+++ b/addons/tiberavonltd@estravon-plugin
@@ -1,0 +1,1 @@
+{"tags": ["ai", "attachment"]}


### PR DESCRIPTION
PDF → markdown attachment plugin for Zotero. https://github.com/tiberavonltd/estravon-plugin (latest release v0.4.9, estravon-0.4.9.xpi).