### PR TITLE
Add SHANGKAIJIE/zotero-dual-title

### DIFF
--- a/addons/SHANGKAIJIE@zotero-dual-title
+++ b/addons/SHANGKAIJIE@zotero-dual-title
@@ -1,1 +1,1 @@
-{"tags":["interface","utility"]}
+{"tags":["interface"]}

--- a/addons/SHANGKAIJIE@zotero-dual-title
+++ b/addons/SHANGKAIJIE@zotero-dual-title
@@ -1,0 +1,1 @@
+{"tags":["interface","utility"]}


### PR DESCRIPTION
Add Dual Title for Zotero — display translated titles as a second row in the item list.

Tags: interface, utility