### PR TITLE
Add FanyiPaiban Zotero PDF Translator

### DIFF
--- a/addons/garlicwu@fanyipaiban-zotero
+++ b/addons/garlicwu@fanyipaiban-zotero
@@ -1,0 +1,1 @@
+{"tags": ["ai", "attachment"]}


### PR DESCRIPTION
## Plugin

- Repository: https://github.com/garlicwu/fanyipaiban-zotero
- Latest release: https://github.com/garlicwu/fanyipaiban-zotero/releases/tag/v0.1.1
- Update manifest: https://github.com/garlicwu/fanyipaiban-zotero/releases/download/release/update.json
- Compatibility: Zotero 7.0 to 9.0.*
- Tags: `ai`, `attachment`

FanyiPaiban PDF Translator sends a selected Zotero PDF attachment to the FanyiPaiban translation service, tracks the task, and imports the translated result back into Zotero. Customer support: 124005421@qq.com.