### PR TITLE
Add Avi7ii/Zotero-glass

### DIFF
--- a/addons/Avi7ii@Zotero-glass
+++ b/addons/Avi7ii@Zotero-glass
@@ -1,0 +1,1 @@
+{"tags": ["interface"]}


### PR DESCRIPTION
## Add-on

- Repository: https://github.com/Avi7ii/Zotero-glass
- Latest release: https://github.com/Avi7ii/Zotero-glass/releases/tag/v0.2.46
- XPI asset: `Zotero-Glass-0.2.46.xpi`
- Compatibility: Zotero 9 on macOS
- Suggested tag: `interface`

Zotero Glass adds native macOS glass materials, translucency, blur, and related appearance controls to Zotero. It is macOS-only and includes an update manifest for automatic updates.

## Validation

- The repository's latest XPI was parsed successfully with this scraper.
- Detected add-on ID: `zotero-glass@avi7ii.github.io`
- Detected version: `0.2.46`
- Detected Zotero range: `9.0` to `9.*`
- Local add-on tag review passed with `interface`.
