### PR TITLE
Add Zotero 生词笔记 (Zzq-02/zotero-vocab-builder)

### DIFF
--- a/addons/Zzq-02@zotero-vocab-builder
+++ b/addons/Zzq-02@zotero-vocab-builder
@@ -1,0 +1,1 @@
+{"tags": ["reader", "notes"]}


### PR DESCRIPTION
Add `Zzq-02/zotero-vocab-builder` to the add-on scraper.

- Display name: Zotero 生词笔记
- Release: https://github.com/Zzq-02/zotero-vocab-builder/releases/tag/v1.0.0
- Tags: reader, notes