### PR TITLE
Add Nayuta-9@zotero-geyi-translator

### DIFF
--- a/addons/Nayuta-9@zotero-geyi-translator
+++ b/addons/Nayuta-9@zotero-geyi-translator
@@ -1,0 +1,1 @@
+{"tags": ["ai", "attachment"]}


### PR DESCRIPTION
Adds [格译 Geyi Zotero 插件](https://github.com/Nayuta-9/zotero-geyi-translator) — one-click translation of PDFs in Zotero; the translated file is imported back as a child attachment of the same item.

- Repo: https://github.com/Nayuta-9/zotero-geyi-translator (AGPL-3.0-or-later)
- Latest release: v0.9.2, with `geyi-translator.xpi` attached
- Zotero 7 (`strict_min_version` 6.999)

Tags: `ai` (translation via LLM) and `attachment` (output managed as item attachments).