### PR TITLE
Add Zotero Semantic Tag Colors

### DIFF
--- a/addons/FOODZERO-hub@zotero-semantic-tag-colors
+++ b/addons/FOODZERO-hub@zotero-semantic-tag-colors
@@ -1,0 +1,1 @@
+{"tags": ["interface", "utility"]}

--- a/addons/FOODZERO-hub@zotero-semantic-tag-colors
+++ b/addons/FOODZERO-hub@zotero-semantic-tag-colors
@@ -1,1 +1,1 @@
-{"tags": ["interface", "utility"]}
+{"tags": ["interface"]}


### PR DESCRIPTION
## Summary

- add `FOODZERO-hub/zotero-semantic-tag-colors` to the addon source list
- classify it as `interface`

## Why

Zotero Semantic Tag Colors is a local-only Zotero plugin that assigns configurable background and text colors to semantic tag categories. It provides a visual rule editor, English and Simplified Chinese localization, and published XPI releases with an update manifest.

Repository: https://github.com/FOODZERO-hub/zotero-semantic-tag-colors

## User impact

After the marketplace data is rebuilt, users can discover the plugin and install its published XPI release from the Zotero addon marketplace.

## Validation

- addon tag review: passed (`interface`)
- automated tag suggestion: matched (`interface`, confidence 0.99)
- test suite: 74 passed
- end-to-end scraper validation: 1 repository processed, 0 failures
- releases parsed successfully: v1.2.0 and v1.1.3
