### PR TITLE
Add Mktero

### DIFF
--- a/addons/tenglvjun@mktero
+++ b/addons/tenglvjun@mktero
@@ -1,0 +1,1 @@
+{"tags": ["reader", "attachment"]}


### PR DESCRIPTION
## Add-on

- Repository: https://github.com/tenglvjun/mktero
- Name: Mktero
- Tags: `reader`, `attachment`
- Zotero compatibility: Zotero 7, 8, and 9

## Description

Mktero is a restartless Zotero extension that converts local PDF attachments into readable Markdown using MinerU. It provides academic-focused rendering for formulas, tables, figures, and citations, together with an outline, figure and reference previews, local result caching, and Zotero annotation synchronization.

The extension supports English and Simplified Chinese. Users provide their own MinerU API token, and PDFs are uploaded to MinerU when no valid local conversion cache is available.

## Release

https://github.com/tenglvjun/mktero/releases/latest

## Verification

- Add-on tag review passed for `reader` and `attachment`
- All 74 repository tests passed