### PR TITLE
add zotero-ima-sync plugin entry

### DIFF
--- a/addons/ANDYPENG09@zotero-ima-sync
+++ b/addons/ANDYPENG09@zotero-ima-sync
@@ -1,0 +1,1 @@
+{"tags": ["integration", "ai"]}

--- a/addons/ANDYPENG09@zotero-ima-sync
+++ b/addons/ANDYPENG09@zotero-ima-sync
@@ -1,1 +1,1 @@
-{"tags": ["integration", "ai"]}
+{"tags": ["integration", "attachment"]}


### PR DESCRIPTION
Add entry for **zotero-ima-sync** (`ANDYPENG09@zotero-ima-sync`).

Sync Zotero items with PDF attachments to the Tencent ima knowledge base (ima.qq.com), building a searchable literature RAG library. Compatible with Zotero 7/8/9.

- Public repo: https://github.com/ANDYPENG09/zotero-ima-sync
- Latest Release: https://github.com/ANDYPENG09/zotero-ima-sync/releases (v0.0.1, xpi asset available)
- Tags: `integration`, `ai`