### PR TITLE
Add metadata tags to niAdd 小61 - AI Medical Translation for Zoteroan1147 addon

### DIFF
--- a/addons/nian1147@-61-
+++ b/addons/nian1147@-61-
@@ -1,0 +1,1 @@
+{"tags": ["ai", "reader"]}


### PR DESCRIPTION
A Zotero 7 plugin for AI-powered medical literature translation. Supports ChatGPT, Claude, Gemini, DeepSeek, and custom OpenAI-compatible endpoints with medical-specific prompts, abbreviation scanning, and glossary post-processing.