### PR TITLE
feat: add ZorroStardust/zotero-vim-plus

### DIFF
--- a/addons/ZorroStardust@zotero-vim-plus
+++ b/addons/ZorroStardust@zotero-vim-plus
@@ -1,0 +1,1 @@
+{"tags": ["reader", "utility"]}


### PR DESCRIPTION
Add Zotero Vim Plus (Vim-style keybindings for the Zotero PDF reader).

- Repo: https://github.com/ZorroStardust/zotero-vim-plus
- Tags: reader, utility
- Latest release: v1.5.0 with auto-update via updates.json
- License: AGPL-3.0