### PR TITLE
Add MCXCC303/just-enough-color

### DIFF
--- a/addons/MCXCC303@just-enough-color
+++ b/addons/MCXCC303@just-enough-color
@@ -1,0 +1,1 @@
+{"tags": ["reader"]}


### PR DESCRIPTION
An add-on that gives colorful highlight & underline more than original.

Repo: https://github.com/MCXCC303/just-enough-color