### PR TITLE
Add Notion Item Opener for Zotero

### DIFF
--- a/addons/yfengup@notion-item-opener-for-zotero
+++ b/addons/yfengup@notion-item-opener-for-zotero
@@ -1,0 +1,1 @@
+{"tags": ["integration", "utility"]}


### PR DESCRIPTION
## Summary

- add `yfengup/notion-item-opener-for-zotero` to the add-on registry
- classify it as `integration` and `utility`

The plugin opens Zotero items directly from trusted Notion links using native Zotero Item Keys. Its v1.1.0 release supports Zotero 8 and 9.

## Validation

- add-on tag review: passed
- tag review unit tests: 7 passed
- end-to-end scraper check: 1 repository processed, 0 failed, v1.1.0 XPI downloaded and parsed successfully for Zotero 8 and 9

Repository: https://github.com/yfengup/notion-item-opener-for-zotero
Release: https://github.com/yfengup/notion-item-opener-for-zotero/releases/tag/v1.1.0