### PR TITLE
Add zhouyi654/zotero-title-translator

### DIFF
--- a/addons/zhouyi654@zotero-title-translator
+++ b/addons/zhouyi654@zotero-title-translator
@@ -1,0 +1,1 @@
+{"tags": ["ai", "interface"]}

--- a/addons/zhouyi654@zotero-title-translator
+++ b/addons/zhouyi654@zotero-title-translator
@@ -1,1 +1,1 @@
-{"tags": ["ai", "interface"]}
+{"tags": ["ai"]}


### PR DESCRIPTION
Adds `zhouyi654/zotero-title-translator` to the Zotero Addons Scraper.

The plugin translates Zotero titles and abstracts, supports multiple translation providers, terminology rules, automatic translation, and a PDF2zh terminology bridge. Current public release targets Zotero 9.0.x.
