### PR TITLE
feat(addons): add Zotero AI Guided Reader

### DIFF
--- a/addons/jhj223@zotero-ai-guided-reader
+++ b/addons/jhj223@zotero-ai-guided-reader
@@ -1,0 +1,1 @@
+{"tags": ["ai", "reader"]}


### PR DESCRIPTION
## 改动目的

将 `jhj223/zotero-ai-guided-reader` 纳入 Zotero Add-on Market 的抓取数据源，供 Zotero 9 用户发现和安装正式版本。

## 主要修改

- 新增 `addons/jhj223@zotero-ai-guided-reader`；
- 按插件的主要用途标记 `ai` 和 `reader`；
- 使用公开 GitHub Release 作为 XPI 来源。

## 验证情况

- 标签校验：通过；
- 仓库测试：74 项通过；
- 单仓库实际抓取：成功生成 1 条插件记录；
- 抓取结果：名称 `Zotero AI 带读`、版本 `0.1.0`、兼容 Zotero `9.0` 至 `9.0.*`；
- 公网 XPI 校验：文件头、manifest、下载链接和 SHA-256 均有效。

## 影响与风险

仅新增一个插件数据源条目，不修改抓取逻辑。插件使用用户自备的第三方账号或 API Key，正式 XPI 未包含授权私钥或支付凭据。未发现明显风险。

## 补充信息

- Release: https://github.com/jhj223/zotero-ai-guided-reader/releases/tag/v0.1.0
- 仓库: https://github.com/jhj223/zotero-ai-guided-reader
