### PR TITLE
Add metadata for zotero-hide-fields addon

### DIFF
--- a/addons/XoYaPeng/zotero-hide-fields
+++ b/addons/XoYaPeng/zotero-hide-fields
@@ -1,0 +1,1 @@
+{"tags": ["interface"]}

--- a/addons/XoYaPeng/zotero-hide-fields
+++ b/addons/XoYaPeng/zotero-hide-fields
@@ -1,1 +1,0 @@
-{"tags": ["interface"]}

--- a/addons/XoYaPeng@zotero-hide-fields
+++ b/addons/XoYaPeng@zotero-hide-fields
@@ -1,0 +1,1 @@
+{"tags": ["interface"]}


### PR DESCRIPTION
用于在条目**信息面板（Info pane）**中按条目类型选择性隐藏字段，并自定义字段顺序。