### PR TITLE
feat(addons): add ECHOUniverse@zotero-translator-next

### DIFF
--- a/addons/ECHOUniverse@zotero-translator-next
+++ b/addons/ECHOUniverse@zotero-translator-next
@@ -1,0 +1,1 @@
+{"tags": ["ai", "reader"]}


### PR DESCRIPTION
## 新增插件

添加 [ZoteroTranslatorNext](https://github.com/ECHOUniverse/zotero-translator-next) 条目。

- **功能**:Zotero 文献翻译插件,支持划选即译、多渠道翻译(MyMemory/DeepSeek/Bing/自定义 OpenAI 兼容渠道)、翻译历史、AI 总结
- **标签**:`ai`(AI 翻译/总结)、`reader`(PDF 阅读器内划选翻译)
- **兼容**:Zotero 7/8/9,manifest 兼容 `6.999 – 9.0.*`
- **发布**:已发布 v0.2.6,Release 含 `zotero-translator-next.xpi` 资产及 update.json 自动更新