### PR TITLE
Add CHENYUZ-hub/zotero-literature-star-citation

### DIFF
--- a/addons/CHENYUZ-hub@zotero-literature-star-citation
+++ b/addons/CHENYUZ-hub@zotero-literature-star-citation
@@ -1,0 +1,1 @@
+{"tags": ["interface", "metadata"]}


### PR DESCRIPTION
## Add-on information

- Repository: https://github.com/CHENYUZ-hub/zotero-literature-star-citation
- Add-on name: Literature Star and Citation for Zotero
- Latest version: v1.3.0
- Supported Zotero version: Zotero 9.0.x
- Tags: interface, metadata

## Description

Adds a 0–5 star importance rating to Zotero literature items and provides quick CSL bibliography previews and copying from the item pane.

## Validation

- [x] The repository is public.
- [x] The XPI is attached to a GitHub Release.
- [x] The XPI installs successfully on Zotero 9.0.6 for Windows.
- [x] The main functions have been tested.
- [x] The manifest contains valid compatibility information.