### PR TITLE
Add Li Yue Zotero addon

### DIFF
--- a/addons/xiaoxiao937@li-yue-zotero
+++ b/addons/xiaoxiao937@li-yue-zotero
@@ -1,0 +1,1 @@
+{"tags": ["ai", "reader"]}

--- a/addons/xiaoxiao937@li-yue-zotero
+++ b/addons/xiaoxiao937@li-yue-zotero
@@ -1,1 +1,1 @@
-{"tags": ["ai", "reader"]}
+{"tags": ["ai", "notes"]}


### PR DESCRIPTION
添加 Zotero 插件「狸阅」。

- 仓库：https://github.com/xiaoxiao937/li-yue-zotero
- 功能：使用同一个 Prompt 批量阅读 PDF，并为每篇文献分别生成独立笔记
- API：支持 DeepSeek、OpenAI 及兼容接口，用户使用自己的 API Key
- 性质：免费、非商业的公益工具
- 标签：AI、reader