### PR TITLE
Add zhi-11/zotero-ai-sidebar

### DIFF
--- a/addons/zhi-11@zotero-ai-sidebar
+++ b/addons/zhi-11@zotero-ai-sidebar
@@ -1,0 +1,1 @@
+{"tags": ["ai", "reader"]}


### PR DESCRIPTION
Registers [Zotero Sentence Translator](https://github.com/zhi-11/zotero-ai-sidebar), a substantially refocused derivative of `xuhan-rgb/zotero-ai-sidebar`.

- Add-on ID: `zotero-sentence-translator@local`
- Tags: `ai`, `reader`
- Latest release: [v0.7.2](https://github.com/zhi-11/zotero-ai-sidebar/releases/tag/v0.7.2)
- Compatibility: Zotero 7-9
- Function: click-to-translate PDF sentences with floating results and color-coded annotations