### PR TITLE
feat: add ChaoPlayer@zotero-glossary

### DIFF
--- a/addons/ChaoPlayer@zotero-glossary
+++ b/addons/ChaoPlayer@zotero-glossary
@@ -1,0 +1,1 @@
+{"tags": ["reader", "ai"]}

--- a/addons/ChaoPlayer@zotero-glossary
+++ b/addons/ChaoPlayer@zotero-glossary
@@ -1,1 +1,1 @@
-{"tags": ["reader", "ai"]}
+{"tags": ["notes", "ai"]}


### PR DESCRIPTION
## Summary

Add a new add-on entry to the `addons` folder:
addons/ChaoPlayer@zotero-glossary → {"tags": ["reader", "ai"]}

**Zotero Glossary** — select a technical term while reading (PDF/EPub/webpage/notes), click a small "专业名词查询" button, and get an LLM-powered explanation (Chinese + English definition + example sentence) from an OpenAI-compatible endpoint (DeepSeek by default). Looked-up terms can be favorited into multiple personal glossary books (EN ⇄ ZH) with create/rename/delete management.

## Why these tags

- `reader` — in-reader term lookup via Zotero's official Reader `renderTextSelectionPopup` event
- `ai` — explanations are generated by an LLM (DeepSeek / any OpenAI-compatible API)

## Requirements check

- [x] Public GitHub repository: https://github.com/ChaoPlayer/zotero-glossary
- [x] Release with XPI attachment: https://github.com/ChaoPlayer/zotero-glossary/releases/download/v0.2.2/zotero-glossary.xpi
- [x] Update manifest: https://raw.githubusercontent.com/ChaoPlayer/zotero-glossary/main/update.json
- [x] MIT License, Zotero 7.0–10.9.9 compatible (manifest declares `applications.zotero`)