### PR TITLE
Add xiaoxuan353/zotero-paper-radar

### DIFF
--- a/addons/xiaoxuan353@zotero-paper-radar
+++ b/addons/xiaoxuan353@zotero-paper-radar
@@ -1,0 +1,1 @@
+{"tags": ["ai", "utility"]}

--- a/addons/xiaoxuan353@zotero-paper-radar
+++ b/addons/xiaoxuan353@zotero-paper-radar
@@ -1,1 +1,1 @@
-{"tags": ["ai", "utility"]}
+{"tags": ["ai", "metadata"]}


### PR DESCRIPTION
论文雷达：Zotero 插件。自动抓取期刊 RSS 订阅源，调用大模型按你的研究方向评估论文相关度，高/中相关文献自动入库并附「AI 研判解读」笔记，低相关自动跳过。支持任意 OpenAI 兼容接口（火山方舟 / DeepSeek / Ollama 等）。