### PR TITLE
Add Jiahaohong/mineru-to-zotero

### DIFF
--- a/addons/Jiahaohong@mineru-to-zotero
+++ b/addons/Jiahaohong@mineru-to-zotero
@@ -1,0 +1,1 @@
+{"tags": ["notes", "attachment"]}


### PR DESCRIPTION
Add MinerU to Zotero, a Zotero plugin that:

- Converts Zotero PDF attachments to Markdown
- Synchronizes PDF highlights to their original positions in parsed Markdown
- Generates an outline-preserving highlight-only Markdown file

Repository: https://github.com/Jiahaohong/mineru-to-zotero
Latest release: https://github.com/Jiahaohong/mineru-to-zotero/releases/tag/v0.1.23
Zotero compatibility: 7.0–9.0.*