### PR TITLE
Add Mengqi97/codex-bilingual-reader-for-zotero

### DIFF
--- a/addons/Mengqi97@codex-bilingual-reader-for-zotero
+++ b/addons/Mengqi97@codex-bilingual-reader-for-zotero
@@ -1,0 +1,1 @@
+{"tags": ["ai", "reader"]}


### PR DESCRIPTION
## What changed

Adds `Mengqi97/codex-bilingual-reader-for-zotero` to the add-on scraper with the `ai` and `reader` tags.

## Why

Codex Bilingual Reader creates preserved-layout English/Chinese PDFs in Zotero using either the locally authenticated Codex CLI or OpenAI-compatible APIs. It supports single and batch translation and imports completed bilingual PDFs back into Zotero.

## Release verification

- Public repository with an MIT license
- Latest stable release: `v1.3.71`
- Release contains `codex-bilingual-reader.xpi`
- Bilingual README, logo, preview, installation, privacy, and configuration documentation are available
- The add-on entry is valid JSON and uses two supported tags
