### PR TITLE
Remove Zotero Semantic Tag Colors

### DIFF
--- a/addons/FOODZERO-hub@zotero-semantic-tag-colors
+++ b/addons/FOODZERO-hub@zotero-semantic-tag-colors
@@ -1,1 +1,0 @@
-{"tags": ["interface"]}


### PR DESCRIPTION
## Summary

- remove `FOODZERO-hub/zotero-semantic-tag-colors` from the addon source list

## Why

The plugin owner no longer wants the plugin listed in the community addon marketplace. This reverses the listing added in #162.

## User impact

After the marketplace data is rebuilt, Zotero Semantic Tag Colors will no longer appear in this marketplace source. The plugin's GitHub repository and existing installations are not changed.

## Validation

- test suite: 74 passed
- `git diff --check`: passed
