### PR TITLE
Add ppavlidis/condense-info-view

### DIFF
--- a/addons/ppavlidis@condense-info-view
+++ b/addons/ppavlidis@condense-info-view
@@ -1,0 +1,1 @@
+{"tags": ["interface"]}


### PR DESCRIPTION
Adds [Condense Info View](https://github.com/ppavlidis/condense-info-view) — declutters the item Info panel: hides empty unimportant fields, dims empty important ones (per item type) as fill-me prompts, and collapses 3+ authors to first ··· last. A "show empty" toggle in the Info header reveals everything.

Latest release: https://github.com/ppavlidis/condense-info-view/releases/latest (XPI published).

Tag: `interface`.