### PR TITLE
Add GinixStudy/zotero-browser

### DIFF
--- a/addons/GinixStudy@zotero-browser
+++ b/addons/GinixStudy@zotero-browser
@@ -1,1 +1,1 @@
-{"tags":["integration","interface"]}
+{"tags":["interface"]}

--- a/addons/GinixStudy@zotero-browser
+++ b/addons/GinixStudy@zotero-browser
@@ -1,0 +1,1 @@
+{"tags":["integration","interface"]}


### PR DESCRIPTION
Adds Zotero Browser to the add-on scraper.

Repository:
https://github.com/GinixStudy/zotero-browser

Latest release:
v0.3.3

Zotero Browser embeds a web browser directly in Zotero's Item Pane, allowing users to browse websites and use web-based research/AI tools without leaving Zotero.

Tested with Zotero 9.0.6.

Tags:
- integration
- interface