### PR TITLE
Add paulMrG2/zotero-highlight-descriptions

### DIFF
--- a/addons/paulMrG2@zotero-highlight-descriptions
+++ b/addons/paulMrG2@zotero-highlight-descriptions
@@ -1,0 +1,1 @@
+{"tags": ["reader", "interface"]}


### PR DESCRIPTION
Adds [Zotero Highlight Color Descriptions](https://github.com/paulMrG2/zotero-highlight-descriptions) — customizable descriptive labels for highlight colors ("Important", "Disagree", …) across the reader's annotation context menu, text-selection popup, and toolbar color picker, with a settings pane and clean pref removal on uninstall.

Latest release: https://github.com/paulMrG2/zotero-highlight-descriptions/releases/latest (XPI published, with SHA256 checksums and GitHub build-provenance attestation).

Tags: `reader`, `interface`.