### PR TITLE
Add Zotero Linked Mindmaps addon

### DIFF
--- a/addons/oekeur@zotero-linked-mindmaps
+++ b/addons/oekeur@zotero-linked-mindmaps
@@ -1,0 +1,1 @@
+{"tags": ["notes", "interface"]}


### PR DESCRIPTION
Adds [Zotero Linked Mindmaps](https://github.com/oekeur/zotero-linked-mindmaps): typed, named links between Zotero items and notes, organized into named mindmaps and rendered as a graph in a "Mindmap" main-window tab, plus a "Connections" item-pane panel listing the selected item's links.

Entry: `addons/oekeur@zotero-linked-mindmaps`, tagged `notes` (link and knowledge management) and `interface` (the Mindmap tab and the Connections item-pane panel). `python3 -m zotero_scraper.tag_review` reports `ok` for the file.

Checked against what the scraper reads:

- The `v0.1.0` release carries `zotero-linked-mindmaps.xpi` with content type `application/x-xpinstall`.
- The xpi's `manifest.json` has a resolved `applications.zotero` block: `id`, `update_url`, `strict_min_version` `6.999`, `strict_max_version` `10.*`.
- `update_url` (https://github.com/oekeur/zotero-linked-mindmaps/releases/download/release/update.json) returns 200 and lists the `0.1.0` entry with a sha512 hash.
- The repository is public and has a README and a description.

Licensed AGPL-3.0-or-later.
