### PR TITLE
chore(addons): add reader tag to wdcpclover/ai4paper

### DIFF
--- a/addons/wdcpclover@ai4paper
+++ b/addons/wdcpclover@ai4paper
@@ -1,1 +1,1 @@
-{"tags": ["ai"]}
+{"tags": ["ai", "reader"]}


### PR DESCRIPTION
Hi, I'm the author of AI4Paper (`wdcpclover/ai4paper`).

This adds a second tag `reader` to our entry, keeping it within the 2-tag limit:

```diff
-{"tags": ["ai"]}
+{"tags": ["ai", "reader"]}
```

### Why `reader`

Besides the AI features it is already tagged for, a large part of the plugin lives inside the Zotero PDF reader:

- **Full-text PDF translation** with a bilingual side-by-side layout, saved back as an attachment
- **Selection translation** popup while reading
- **Reading-pane assistant** for asking questions about the current PDF, with annotation support

That matches the taxonomy description of `reader` ("PDF reading experience, annotation, and highlighting workflows"), and it is consistent with how comparable entries are tagged (e.g. `WildDataX/suppr-zotero-plugin`, `lss3765/Zotero-Bilingual-Reader-Public`, `SRT117/LitMTrans-Zotero` all use `ai` + `reader`).

Our entry briefly carried five tags back in April, which was correctly trimmed to one in 2680242. This time it stays at the documented maximum of two, and I'm not touching `recommended`.

Thanks for maintaining this list!
