### PR TITLE
Add four add-ons: Theorem List, DJVU to PDF Converter, Reading Time, Tag Explorer

### DIFF
--- a/addons/ievlevpn@zotero-djvu-converter
+++ b/addons/ievlevpn@zotero-djvu-converter
@@ -1,0 +1,1 @@
+{"tags": ["attachment"]}

--- a/addons/ievlevpn@zotero-tag-explorer
+++ b/addons/ievlevpn@zotero-tag-explorer
@@ -1,0 +1,1 @@
+{"tags": ["reader"]}

--- a/addons/ievlevpn@zotero-theorem-list
+++ b/addons/ievlevpn@zotero-theorem-list
@@ -1,0 +1,1 @@
+{"tags": ["reader"]}

--- a/addons/ievlevpn@zotero-time-tracking
+++ b/addons/ievlevpn@zotero-time-tracking
@@ -1,0 +1,1 @@
+{"tags": ["reader", "utility"]}


### PR DESCRIPTION
Adds four add-ons. All four repos are public and each has a latest release with an `.xpi` asset carrying a `manifest.json`.

| Entry | Add-on | What it does | Tags |
|---|---|---|---|
| `ievlevpn@zotero-theorem-list` | [Theorem List](https://github.com/ievlevpn/zotero-theorem-list) | Lists theorems, lemmas, propositions and corollaries found in a PDF from the reader toolbar, with fuzzy search and click-to-jump | `reader` |
| `ievlevpn@zotero-djvu-converter` | [DJVU to PDF Converter](https://github.com/ievlevpn/zotero-djvu-converter) | Converts DJVU attachments to PDF, with OCR and compression | `attachment` |
| `ievlevpn@zotero-time-tracking` | [Reading Time](https://github.com/ievlevpn/zotero-time-tracking) | Stopwatch, pomodoro and manual entry in the reader toolbar; per-item totals as an info row and an item-tree column, plus a history window with a heatmap | `reader`, `utility` |
| `ievlevpn@zotero-tag-explorer` | [Tag Explorer](https://github.com/ievlevpn/zotero-tag-explorer) | A window for browsing annotation tags: fuzzy tag search, the highlights and comments behind each tag grouped by book, scoped to a collection | `reader` |

Ran the scraper locally over just these four entries first — 4 repos processed, 0 failed, and every `targetZoteroVersion` slot resolves to a release with a working download URL.
