### PR TITLE
Add Yuriyagn/zotero-pdf2zh

### DIFF
--- a/addons/Yuriyagn@zotero-pdf2zh
+++ b/addons/Yuriyagn@zotero-pdf2zh
@@ -1,0 +1,1 @@
+{"tags": ["ai", "reader"]}

--- a/addons/Yuriyagn@zotero-pdf2zh
+++ b/addons/Yuriyagn@zotero-pdf2zh
@@ -1,1 +1,1 @@
-{"tags": ["ai", "reader"]}
+{"tags": ["ai", "attachment"]}


### PR DESCRIPTION
## Zotero PDF 中文翻译

- Repository: https://github.com/Yuriyagn/zotero-pdf2zh
- Latest release: https://github.com/Yuriyagn/zotero-pdf2zh/releases/latest
- Zotero compatibility: Zotero 8 and Zotero 9
- License: AGPL-3.0-or-later
- Plugin ID: `zotero-pdf2zh@yuriyagn.github.io`

This plugin invokes PDFMathTranslate Next or the legacy PDFMathTranslate backend from Zotero, translates the selected PDF into Simplified Chinese, and attaches the translated PDF to the original Zotero item.

This submission refers specifically to `Yuriyagn/zotero-pdf2zh`; it is a separate repository from the existing `guaguastandup/zotero-pdf2zh` entry.

Users configure their own SiliconFlow API key. Extracted PDF text is sent to SiliconFlow for translation; the privacy disclosure is documented in the README. The plugin does not include an API key or telemetry.

### Local validation

- Add-on tag review: passed (`ai`, `attachment`)
- Scraper release-cache build: 1 repository processed, 1 release parsed, 0 errors
- Release asset tested: `zotero-pdf2zh-0.2.3.xpi`
