### PR TITLE
Add ievlevpn/zotero-tag-fuzzy-search

### DIFF
--- a/addons/ievlevpn@zotero-tag-fuzzy-search
+++ b/addons/ievlevpn@zotero-tag-fuzzy-search
@@ -1,0 +1,1 @@
+{"tags": ["interface", "utility"]}


### PR DESCRIPTION
Adds [Tag Fuzzy Search](https://github.com/ievlevpn/zotero-tag-fuzzy-search).

Zotero's tag autocomplete matches only the start of a tag, so `learn` never suggests `machine learning`. This plugin makes the match fuzzy and ranks the suggestions, everywhere tags are entered or filtered — the item pane, the note editor, the reader's annotation tag popup, advanced search, and the tag selector pane.

Tagged `interface`, `utility`, matching the convention of similar tag add-ons in the index.