### PR TITLE
Add RapidOCR for Zotero (chen7447/rapidocr-for-zotero)

### DIFF
--- a/addons/chen7447@rapidocr-for-zotero
+++ b/addons/chen7447@rapidocr-for-zotero
@@ -1,0 +1,1 @@
+{"tags": ["attachment"]}


### PR DESCRIPTION
开装即用的 Zotero PDF OCR 插件。无需 Python / Tesseract。

- Repo: https://github.com/chen7447/rapidocr-for-zotero
- Release: https://github.com/chen7447/rapidocr-for-zotero/releases/tag/v1.6.0b6
- Tag: attachment（OCR / 附件）