### PR TITLE
Add Paper Chat for Zotero

### DIFF
--- a/addons/Suzuka24@paper-chat-for-zotero
+++ b/addons/Suzuka24@paper-chat-for-zotero
@@ -1,0 +1,1 @@
+{"tags": ["ai", "reader"]}


### PR DESCRIPTION
## Summary

Add [Paper Chat for Zotero](https://github.com/Suzuka24/paper-chat-for-zotero) to the addon scraper catalog.

The plugin adds paper-aware Codex chat to the Zotero PDF reader and supports Zotero 9 on Windows and macOS. Its public [v0.6.0 release](https://github.com/Suzuka24/paper-chat-for-zotero/releases/tag/v0.6.0) includes a parseable XPI asset with the correct add-on ID and Zotero compatibility range.

## Tags

- `ai`: local Codex-powered paper chat
- `reader`: integrates with the Zotero PDF reader and uses PDF context, selections, and annotations

## Validation

- `python -m zotero_scraper.tag_review --files addons/Suzuka24@paper-chat-for-zotero`
- `pytest tests/unit/test_tag_review.py`: 7 passed

## Installation note

First-time setup also requires the platform installer to install the local bridge. This is prominently documented in the repository README and release notes.