### PR TITLE
add: sci-download-for-zotero

### DIFF
--- a/addons/chen7447@sci-download-for-zotero
+++ b/addons/chen7447@sci-download-for-zotero
@@ -1,0 +1,1 @@
+{"tags": ["attachment"]}


### PR DESCRIPTION
## Sci-Download For Zotero

Zotero 7+ 插件，通过 Sci-Hub 镜像站搜索并下载 PDF。

- GitHub: https://github.com/chen7447/sci-download-for-zotero
- Release: https://github.com/chen7447/sci-download-for-zotero/releases/tag/v1.1.2
- Tags: attachment