### PR TITLE
Add endoretic/zotero-wallpaper

### DIFF
--- a/addons/endoretic@zotero-wallpaper
+++ b/addons/endoretic@zotero-wallpaper
@@ -1,0 +1,1 @@
+{"tags": ["interface"]}


### PR DESCRIPTION
Add [Zotero Wallpaper](https://github.com/endoretic/zotero-wallpaper), a local wallpaper plugin for Zotero 10.

- Supports a single image or wallpaper folder
- Random wallpaper on startup and timed rotation
- Adjustable opacity and Cover/Contain/Center/Stretch layouts
- English and Chinese settings UI
- Latest release: [v0.2.1](https://github.com/endoretic/zotero-wallpaper/releases/tag/v0.2.1)
- Update manifest: https://github.com/endoretic/zotero-wallpaper/releases/latest/download/updates.json
- Category: `interface`

The add-on entry passes the repository's local tag validator.