### PR TITLE
Add PaperMind (xutoya/paper-mind)

### DIFF
--- a/addons/xutoya@paper-mind
+++ b/addons/xutoya@paper-mind
@@ -1,0 +1,1 @@
+{"tags": ["ai", "reader"]}


### PR DESCRIPTION
Add **PaperMind** (`xutoya/paper-mind`) to the addon scraper index.

- Fork of [paper-chat-for-zotero](https://github.com/syt2/paper-chat-for-zotero)
- Distinct addon ID — installable alongside upstream
- Release: https://github.com/xutaoya/paper-mind/releases/tag/V3.1.2
- Tags: `ai`, `reader`