### PR TITLE
Add RSSrch for Zotero

### DIFF
--- a/addons/SolveSaint@RSSrch-for-Zotero
+++ b/addons/SolveSaint@RSSrch-for-Zotero
@@ -1,0 +1,1 @@
+{"tags": ["utility", "interface"]}

--- a/addons/SolveSaint@RSSrch-for-Zotero
+++ b/addons/SolveSaint@RSSrch-for-Zotero
@@ -1,1 +1,1 @@
-{"tags": ["utility", "interface"]}
+{"tags": ["utility"]}


### PR DESCRIPTION
Adds [RSSrch for Zotero](https://github.com/SolveSaint/RSSrch-for-Zotero) by SolveSaint.

RSSrch extends Zotero's built-in RSS feeds into a discovery workflow: feeds organised in
nested folders, aggregate views with deduplication, global and per-feed rules with weighted
scoring and relevance ranking, an in-app feed reader, and feed-value metrics.

- Release with XPI: https://github.com/SolveSaint/RSSrch-for-Zotero/releases/tag/v1.0.0
- Announcement: https://forums.zotero.org/discussion/133430/plugin-rssrch
- Targets Zotero 10+

Tags: `utility`, `interface` — happy to adjust if the tag review suggests otherwise
(`ai` is also arguable, since the setup wizard is AI-assisted, but that is a
configuration aid rather than the plugin's purpose).

One note for the maintainers, since it is a policy call rather than something I should
decide by filing: the GitHub repository holds the documentation site and the releases, not
the plugin source. The shipped XPI does contain fully readable, unminified source, so the
code is auditable — there is simply no source repository or commit history for it.
