### PR TITLE
Add xujialiu@Zotero-TTS

### DIFF
--- a/addons/xujialiu@Zotero-TTS
+++ b/addons/xujialiu@Zotero-TTS
@@ -1,0 +1,1 @@
+{"tags": ["reader"]}


### PR DESCRIPTION
Adds an entry for [Zotero-TTS](https://github.com/xujialiu/Zotero-TTS), a plugin for Zotero 10.

It enhances Zotero's built-in Read Aloud: extra voices (OpenAI-compatible servers, Azure Speech, a local Kokoro-FastAPI), word and sentence highlighting at the same time in user-chosen colors, speed and sentence/paragraph navigation shortcuts, one voice and speed across documents, and settings backup to a file or WebDAV.

Tag: `reader`.

Releases carry a `zotero-tts.xpi` asset, and the manifest declares `applications.zotero` with `id`, `update_url` and `strict_min_version` / `strict_max_version`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
