### PR TITLE
Add ievlevpn/zotero-feed-riffle

### DIFF
--- a/addons/ievlevpn@zotero-feed-riffle
+++ b/addons/ievlevpn@zotero-feed-riffle
@@ -1,0 +1,1 @@
+{"tags": ["interface", "utility"]}


### PR DESCRIPTION
Adds [Feed Riffle](https://github.com/ievlevpn/zotero-feed-riffle).

Zotero's feed reader is a three-pane library view: click an item, read it, click *Add to My Library*, wait for a translator, pick a collection in a dialog. Fine for a handful a week; at a couple of thousand unread it is why the backlog exists. This deals the unread items out one card at a time and puts the decision on the arrow keys — left discards, right opens a fuzzy collection picker preloaded with the last one used, with optional tags and a note.

Discarding is Zotero's own per-item read flag, so unread counts in the collections pane stay in step and nothing is left behind if the plugin is removed. Descriptions are rendered rather than flattened: feed HTML is sanitized through `nsIParserUtils`, and LaTeX is typeset with a bundled KaTeX.

Tagged `interface`, `utility`, matching the convention of similar workflow add-ons in the index.