### PR TITLE
Add Zotero Wordbook

### DIFF
--- a/addons/StarKujo@zotero-wordbook
+++ b/addons/StarKujo@zotero-wordbook
@@ -1,0 +1,1 @@
+{"tags":["reader","utility"]}

--- a/addons/StarKujo@zotero-wordbook
+++ b/addons/StarKujo@zotero-wordbook
@@ -1,1 +1,1 @@
-{"tags":["reader","utility"]}
+{"tags":["reader","notes"]}


### PR DESCRIPTION
Adds the public Zotero Wordbook plugin entry. The plugin saves selected English terms with Chinese translations and source context. It depends on Translate for Zotero for automatic translation. Tags: reader, utility.