### PR TITLE
Add journal-tags (chen7447/journal-tags)

### DIFF
--- a/addons/chen7447@journal-tags
+++ b/addons/chen7447@journal-tags
@@ -1,0 +1,1 @@
+{"tags": ["metadata", "interface"]}


### PR DESCRIPTION
插件名：Journal Tags

仓库：chen7447/journal-tags

Release：https://github.com/chen7447/journal-tags/releases/tag/v0.3.1

标签：metadata, interface

简介：Zotero 条目列表显示 EasyScholar 期刊标签与影响因子，影响因子徽标按视图 min–max 长短条可视化，支持分区配色、缓存过期自动刷新与列头右键快捷刷新。