### PR TITLE
Add nyaru177/ccf-for-zotero

### DIFF
--- a/addons/nyaru177@ccf-for-zotero
+++ b/addons/nyaru177@ccf-for-zotero
@@ -1,0 +1,1 @@
+{"tags": ["metadata"]}


### PR DESCRIPTION
Add CCF for Zotero to the addons list.

- Repo: https://github.com/nyaru177/ccf-for-zotero
- An offline assistant that displays CCF (A/B/C, T1/T2/T3) and CAS (Q1-Q4) rankings for journals and conferences in Zotero
- Latest release: v0.2.5, .xpi assets attached
- Suggested tag: metadata